### PR TITLE
add libreadline-dev dependency for ruby 2.1.2

### DIFF
--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -89,3 +89,4 @@ end
     only_if { apt_installed? }
   end
 end
+package 'libreadline-dev'


### PR DESCRIPTION
This was added to rails-app-single, and we need it here too.